### PR TITLE
feat: implement sidemenu and connect header toggle 

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: ✨ 기능 구현
 about: 새로운 기능을 구현합니다
-title: 'Featrue:'
+title: 'Feature:'
 labels: feature
 ---
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,18 +1,23 @@
+import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 
 import { HEADER_HEIGHT } from '@/constants'
 
 import Footer from './Footer'
 import Header from './header'
+import SideMenu from './sidemenu'
 
 export default function Layout() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
   return (
     <div>
-      <Header />
+      <Header onMenuToggle={() => setIsMenuOpen((prev) => !prev)} />
       <main style={{ paddingTop: HEADER_HEIGHT }}>
         <Outlet />
       </main>
       <Footer />
+      <SideMenu isOpen={isMenuOpen} onClose={() => setIsMenuOpen(false)} />
     </div>
   )
 }

--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -1,3 +1,0 @@
-export default function SideMenu() {
-  return <div>SideMenu</div>
-}

--- a/src/components/layout/header/HeaderUser.tsx
+++ b/src/components/layout/header/HeaderUser.tsx
@@ -1,13 +1,17 @@
-import { CircleUserRoundIcon } from 'lucide-react'
+import { CircleUserRoundIcon, MenuIcon } from 'lucide-react'
 
 import { Button } from '@/components'
 
-export default function HeaderUser() {
+type HeaderProps = {
+  onMenuToggle: () => void
+}
+
+export default function HeaderUser({ onMenuToggle }: HeaderProps) {
   // TODO: supabase Auth 셋팅 후 변경 예정
   const isLoggedIn = false
 
   return (
-    <div>
+    <div className="flex items-center gap-3">
       {isLoggedIn ? (
         <CircleUserRoundIcon size={24} />
       ) : (
@@ -15,6 +19,9 @@ export default function HeaderUser() {
           로그인
         </Button>
       )}
+      <Button variant="ghost" onClick={onMenuToggle}>
+        <MenuIcon size={24} />
+      </Button>
     </div>
   )
 }

--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -5,7 +5,11 @@ import { NAV_ITEMS, ROUTES } from '@/constants'
 
 import HeaderUser from './HeaderUser'
 
-export default function Header() {
+type HeaderProps = {
+  onMenuToggle: () => void
+}
+
+export default function Header({ onMenuToggle }: HeaderProps) {
   return (
     <header className="fixed top-0 right-0 left-0 flex h-18 items-center justify-between px-[100px]">
       <div className="flex gap-20">
@@ -22,7 +26,8 @@ export default function Header() {
           </ul>
         </nav>
       </div>
-      <HeaderUser />
+
+      <HeaderUser onMenuToggle={onMenuToggle} />
     </header>
   )
 }

--- a/src/components/layout/sidemenu/index.tsx
+++ b/src/components/layout/sidemenu/index.tsx
@@ -1,5 +1,4 @@
 import { X } from 'lucide-react'
-import { useEffect, useRef } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import logo from '@/assets/keynema.svg'

--- a/src/components/layout/sidemenu/index.tsx
+++ b/src/components/layout/sidemenu/index.tsx
@@ -1,0 +1,87 @@
+import { X } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+
+import logo from '@/assets/keynema.svg'
+import { Button } from '@/components/common/button/Button'
+import { NAV_ITEMS, ROUTES } from '@/constants'
+import { cn } from '@/utils/cn'
+
+type SideMemuProps = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export default function SideMenu({ isOpen, onClose }: SideMemuProps) {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const handleNavigate = (path: string) => {
+    navigate(path)
+    onClose()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40"
+        onClick={onClose}
+        onKeyDown={(e) => e.key === 'Escape' && onClose()}
+        tabIndex={0}
+        role="button"
+        aria-label="메뉴닫기"
+      />
+      <div className="fixed top-0 right-0 left-0 z-50 bg-black/20 px-25 pt-6 pb-16 backdrop-blur-md">
+        <Link to={ROUTES.HOME} onClick={onClose}>
+          <img src={logo} alt="keynema-logo" width={128} height={50} />
+        </Link>
+        <Button
+          variant="ghost"
+          onClick={onClose}
+          className="absolute top-5 right-25"
+        >
+          <X size={28} />
+        </Button>
+
+        <nav className="relative mt-40 flex gap-30">
+          <div
+            className="absolute right-0 left-0 mt-10 border-b border-white/40"
+            style={{ top: 0 }}
+          />
+          {NAV_ITEMS.map((item) => (
+            <div key={item.path} className="flex flex-col">
+              <span
+                className={cn(
+                  'cursor-pointer border-b-2 border-transparent pb-1 text-3xl font-bold text-white transition-colors',
+                  'z-50 hover:border-primary hover:text-primary'
+                )}
+              >
+                {item.label}
+              </span>
+              <ul className="flex flex-col gap-1">
+                {item.subItems?.map((sub) => (
+                  <li key={sub.path}>
+                    <Button
+                      variant="text"
+                      onClick={() => handleNavigate(sub.path)}
+                      className={cn(
+                        'px-2 py-3 text-left text-lg transition-colors hover:text-primary',
+                        location.pathname === sub.path
+                          ? 'font-semibold text-primary'
+                          : 'text-white'
+                      )}
+                    >
+                      {sub.label}
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </nav>
+      </div>
+    </>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable react-refresh/only-export-components */
 // src/router/index.tsx
 import { lazy, Suspense } from 'react'
-import { createBrowserRouter, Outlet } from 'react-router-dom'
+import { createBrowserRouter } from 'react-router-dom'
 
 import { PageLoader } from '@/components'
+import Layout from '@/components/layout/Layout'
 import { ROUTES } from '@/constants'
 
 const DevPage = lazy(() => import('@/pages/DevPage'))
@@ -23,10 +24,12 @@ const withSuspense = (Component: React.ComponentType) => (
 export const router = createBrowserRouter([
   {
     path: ROUTES.HOME,
-    element: <Outlet />, // 나중에 Layout으로 교체
+    element: <Layout />,
     children: [
       { index: true, element: withSuspense(HomePage) },
-      { path: 'dev', element: withSuspense(DevPage) },
+      ...(import.meta.env.DEV
+        ? [{ path: 'dev', element: withSuspense(DevPage) }]
+        : []),
       { path: ROUTES.SEARCH, element: withSuspense(SearchPage) },
       { path: ROUTES.MOVIE_DETAIL, element: withSuspense(MovieDetailPage) },
       { path: ROUTES.MY_PAGE, element: withSuspense(MyPage) },


### PR DESCRIPTION

## 📌 관련 이슈

Closes #10 

## ✨ 변경 내용

- Layout에서 isMenuOpen 상태 관리 및 Header/SideMenu 연결
- SideMenu 폴더 구조 변경(SideMenu => sidemenu/index.tsx)
- HeaderUser에 햄버거버튼 추가 및 onMenuToggle prop 연결
- Header에 onMenuToggle prop 추가
- 라우터 Layout 적용

## 📸 스크린샷
<img width="1904" height="765" alt="image" src="https://github.com/user-attachments/assets/259bc49f-d089-4e26-87db-5b3db90477ad" />



## 📚 참고사항
